### PR TITLE
Save test report in a dedicated file

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,17 @@ On **mocha-test** for use with grunt
 		coverage: {
 			options: {
 				reporter: 'mocha-sonar-generic-test-coverage',
-				quiet: true,
-				captureFile: 'unit-tests.xml'
+				quiet: false
 			},
 			src: [
 				'test.js'
 			]
 		}
+	}
+
+If you want to write your report in a specific file (instead of standard output by default), add the following environment variable with the path to the report file:
+	env: {
+    	mocha_sonar_generic_test_coverage_outputfile:'output/unit-tests.xml'
 	}
 
 # Output example 

--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ module.exports = function (runner) {
 	var stack = {};
 	var title;
 	runner.on('test end', function(test){
-		var file = test.file.substr(test.file.indexOf(process.cwd()) + process.cwd().length + 1);
+		var file = test.file;
 		stackF = stack[file];
 		if(!stackF){
 			stackF = stack[file] = [];

--- a/index.js
+++ b/index.js
@@ -1,7 +1,19 @@
 var fs = require('fs'),
 		util = require('util');
+var path = require('path');
+var mkdirpSync = require('mkdirp').sync;
+var os = require('os');
+
+var logFd;
 
 module.exports = function (runner) {
+	
+	var outputfile = process.env.mocha_sonar_generic_test_coverage_outputfile;
+
+    if (outputfile) {
+		mkdirpSync(path.dirname(outputfile));
+		logFd = fs.openSync(outputfile, 'w');
+    }
 
 	var stack = {};
 	var title;
@@ -69,11 +81,19 @@ module.exports = function (runner) {
 			append('	</file>');
 		});
 		append('</unitTest>');
+		
+		if(logFd !== undefined) {
+			fs.closeSync(logFd);
+		}
 	});
 };
 function append(str) {
-	process.stdout.write(str);
-	process.stdout.write('\n');
+	if(logFd !== undefined) {
+		fs.writeSync(logFd, str + os.EOL);
+	} else {
+		process.stdout.write(str);
+		process.stdout.write('\n');
+	}
 };
 function espape(str){
 	str = str || '';

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
 	"keywords": ["mocha", "sonar", "coverage", "generic test"],
 	"license": "MIT",
 	"main": "index.js",
+	"dependencies": {
+		"mkdirp": "0.5.1"
+	},
 	"maintainers": [
 		{
 			"name": "Elvis de Freitas",


### PR DESCRIPTION
Hello,

There is a problem with the actual plugin configuration. If you use this configuration:
```	
mochaTest: {
	coverage: {
		options: {
			reporter: 'mocha-sonar-generic-test-coverage',
			quiet: true,
			captureFile: 'unit-tests.xml'
		},
		src: [
			'test.js'
		]
	}
}
```
both standard output and report will be written in unit-test.xml

This pull request fixes this by using a dedicated file for the test report.

I also set the absolute filepath for test files in the report because I encountered a problem with Sonar (it doesn't find my file tests when applying the sensor GenericCoverageSensor)

Could you please merge this PR and publish it in npm ?

Thanks

Guilhem