### PR TITLE
Run tests on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"mocha": "^3.0.2"
 	},
 	"scripts": {
-		"test": "./node_modules/mocha/bin/mocha test"
+		"test": "node node_modules/mocha/bin/mocha test"
 	},
 	"maintainers": [
 		{

--- a/test/MochaGenericReport.js
+++ b/test/MochaGenericReport.js
@@ -31,7 +31,7 @@ describe('Mocha Sonar Generic Report', function(){
 	</file>
 </unitTest>
 `;
-			assert.deepEqual(actualContent, expected);
+			assertXML(actualContent, expected);
 
 		});
 
@@ -62,7 +62,7 @@ describe('Mocha Sonar Generic Report', function(){
 	</file>
 </unitTest>
 `;
-			assert.deepEqual(actualContent, expected);
+			assertXML(actualContent, expected);
 
 		});
 
@@ -89,7 +89,7 @@ describe('Mocha Sonar Generic Report', function(){
 	</file>
 </unitTest>
 `;
-			assert.deepEqual(actualContent, expected);
+			assertXML(actualContent, expected);
 
 		});
 
@@ -114,13 +114,23 @@ describe('Mocha Sonar Generic Report', function(){
 </unitTest>
 `;
 			unhook();
-			assert.deepEqual(actualContent, expected);
+			assertXML(actualContent, expected);
 
 		});
 
 	});
 
 });
+
+function replaceAll(string, search, replacement) {
+    return string.split(search).join(replacement);
+};
+
+function assertXML(actual, expected) {
+	var actual = replaceAll(actual, '\r\n', '\n');
+    var expected = replaceAll(expected, '\r\n', '\n');
+	assert.deepEqual(actual, expected);
+}
 
 
 function getFileContent(reportFile){


### PR DESCRIPTION
Tests didn't work on windows due to the following reasons:
- Tests were sensitive to CRLF vs. LF.
- NPM scripts command line was unix-style only.

The following fixes were applied:
- Fixed CRLF/LF issues by making tests ignore different line endings.
- Invoking via node instead of directly calling the mocha script, now.

Tests work nicely in a bash on windows, now.